### PR TITLE
#23 | header values that exceed one line are now truncated

### DIFF
--- a/components/ExpandableText.js
+++ b/components/ExpandableText.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Text } from 'react-native';
+
+export class ExpandableText extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      text: props.text,
+      truncated: 1,
+    };
+  }
+
+  _handleTruncate = () => {
+    const isTruncated = this.state.truncated;
+    this.setState({
+      truncated: 1 - isTruncated,
+    });
+  }
+
+  render() {
+    return (
+      <Text
+        numberOfLines={this.state.truncated}
+        onPress={this._handleTruncate}
+      >
+        {this.state.text}
+      </Text>
+    );
+  }
+}

--- a/screens/HomeScreen.js
+++ b/screens/HomeScreen.js
@@ -37,6 +37,8 @@ import normalize from 'normalize-url';
 
 import { MonoText } from '../components/StyledText';
 
+import { ExpandableText } from '../components/ExpandableText';
+
 import styles from '../styles/homeScreen/style';
 
 export default class HomeScreen extends React.Component {
@@ -82,8 +84,8 @@ export default class HomeScreen extends React.Component {
       return (<List>
         {Object.keys(this.state.responseHeaders).map((headerKey) => (
           <ListItem key={headerKey}>
-            <Left><Text>{headerKey}</Text></Left>
-            <Right><Text>{this.state.responseHeaders[headerKey]}</Text></Right>
+            <Left><ExpandableText text={headerKey} /></Left>
+            <Right><ExpandableText text={this.state.responseHeaders[headerKey]} /></Right>
           </ListItem>
         ))}
       </List>);


### PR DESCRIPTION
Truncated headers that are too long and added a toggle to expand and view entire header values.