### PR TITLE
#34 | Use local storage to save and fetch request history

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,11 +1,13 @@
 import Expo from 'expo';
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { AsyncStorage, StyleSheet, View } from 'react-native';
 import { FontAwesome } from '@expo/vector-icons';
 import { Root } from 'native-base';
 
 import Navigator from './navigation/RootNavigation';
 import cacheAssetsAsync from './utilities/cacheAssetsAsync';
+
+const HISTORY_KEY = 'request_history';
 
 class AppContainer extends React.Component {
   state = {
@@ -15,6 +17,11 @@ class AppContainer extends React.Component {
 
   componentWillMount() {
     this._loadAssetsAsync();
+    AsyncStorage.getItem(HISTORY_KEY).then((value) => {
+      if (value != null) {
+        this.setState({ requestHistory: JSON.parse(value) });
+      }
+    }).then(this.setState({ appIsReady: true }));
   }
 
   async _loadAssetsAsync() {
@@ -35,13 +42,17 @@ class AppContainer extends React.Component {
           'network timeout, so we skipped caching. Reload the app to try again.'
       );
       console.log(e.message);
-    } finally {
-      this.setState({ appIsReady: true });
     }
   }
 
+  _updateLocalStorage = () => {
+    AsyncStorage.setItem(HISTORY_KEY, JSON.stringify(this.state.requestHistory));
+  }
+
   updateRequestHistory = (request) => {
-    this.setState({ requestHistory: [request, ...this.state.requestHistory] });
+    this.setState({ requestHistory: [request, ...this.state.requestHistory] },
+      this._updateLocalStorage
+    );
   }
 
   render() {


### PR DESCRIPTION
Local storage will now be used to save a user's request history to allow them to view it again on app reload.